### PR TITLE
Allow selecting components before starting a system

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,6 +912,28 @@ Here's what that might look like:
       (is (= [:foo] @test-atom)))))
 ```
 
+### Selecting Components
+
+If you want to test only the specific parts of the bigger system, you might do that with `ds/select-components`:
+
+``` clojure
+(defmethod ds/named-system ::test
+  [_]
+  {::ds/defs {:group-a {:a #::ds{:start  "component a"
+                                 :config {:c (ds/ref [:group-b :c])}}
+                        :b #::ds{:start  "component b"}}
+              :group-b {:c #::ds{:start "component c"}
+                        :d #::ds{:start "component d"}}}})
+
+(def some-test
+  (ds/with-*system* (-> (ds/system ::test)
+                        (ds/select-components #{[:group-a :a]}))
+    (is (= {:group-b {:c "component c"}  ;; only relevant components get instantized
+            :group-a {:a "component a"}} ;; components b and d were skipped
+           (::ds/instances ds/*system*)))))
+```
+
+
 # Advanced usage
 
 The topics covered so far should let you get started defining components and


### PR DESCRIPTION
I've noticed playing with the newest testing helpers (big kudos for them btw 🙌 ) that [select components feature](https://github.com/donut-party/system#selecting-components) works only when you pass components-ids directly at the start signal. This made it impossible to use this feature together with `with-*system*` or `system-fixture` but I think it could be very beneficial to be able to select only the specific parts of the bigger system in tests.
For example, you want to test a real system but instead of mocking the irrelevant parts you can just specify what exact components you want to be tested and only those and their dependencies would get instantized.