### PR TITLE
Fix seqs of refs being reversed after resolving

### DIFF
--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -319,9 +319,11 @@
    (fn [x] (or (map? x) (sequential? x)))
    seq
    (fn [p xs]
-     (if (and p (map-entry? p))
-       (into [] xs)
-       (into (empty p) xs)))
+     (cond
+       (nil? p) nil
+       (map-entry? p) (into [] xs)
+       (seq? p) (seq xs)
+       :else (into (empty p) xs)))
    m))
 
 (defn registry-ref->ref


### PR DESCRIPTION
Ref resolution is handled through a zipper, but the zipper node creation function doesn't handle seqs correctly.
`(into (empty p) xs)` results in the items in reverse order of xs due to the semantics of conj.

The fix is to detect when the original collection is a seq and simply use `(seq xs)` as the new node value. I also added an initial check for nil in order to simplify the following conditionals.

This bug can be encountered easily when someone is using a convenience function that uses `& args`, as in the following example:

```clojure
(defn merge-refs [& args]
  {::ds/config {:args args}
   ::ds/start (fn [{{:keys [args]} ::ds/config}]
                (apply merge args))})

(defn http-config-component []
  (merge-refs (ds/local-ref [:env :http])
              (ds/local-ref [:config-file :http])))
```

This is a regression from an earlier version that was most likely introduced when switching from specter.