### PR TITLE
Allow strings and symbols in deep refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## Unreleased
+
+### Added
+
+### Changed
+
+- Allow strings and symbols in deep ref paths.
+
+
 ## 2022-06-25 0.0.165
 
 ### Added

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -179,9 +179,16 @@
 (def ref? (m/validator DonutRef))
 (def ref-type (fn [v] (when (seqable? v) (first v))))
 
-(defn ref [k] [::ref k])
-(defn local-ref [k] [::local-ref k])
-(defn registry-ref [k] [::registry-ref k])
+(defn- ensure-valid-ref [ref]
+  (when-let [explanation (m/explain DonutRef ref)]
+    (throw (ex-info (str "Invalid ref: " (pr-str ref))
+                    {:spec-explain-human (me/humanize explanation)
+                     :spec-explain       explanation})))
+  ref)
+
+(defn ref [k] (ensure-valid-ref [::ref k]))
+(defn local-ref [k] (ensure-valid-ref [::local-ref k]))
+(defn registry-ref [k] (ensure-valid-ref [::registry-ref k]))
 (def ref-key second)
 
 (defn group-ref?

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -119,8 +119,11 @@
 (def ComponentSelection
   [:or ComponentGroupName ComponentId])
 
+(def RegistryKey
+  keyword?)
+
 (def Registry
-  [:map-of keyword? ComponentId])
+  [:map-of RegistryKey ComponentId])
 
 (def PluginSystem
   [:map
@@ -151,27 +154,45 @@
 (def system? (m/validator DonutSystem))
 
 
-(def RefKey
+(def DeepRefPathKey
+  [:or keyword? string? symbol?])
+
+(def LocalRefKey
   [:and
    [:vector :any]
-   [:cat
-    keyword?
-    [:* [:or keyword? string? symbol?]]]])
+   [:catn
+    [:component-name ComponentName]
+    [:deep-ref-path [:* DeepRefPathKey]]]])
 
 (def LocalRef
   [:catn
    [:ref-type [:enum ::local-ref]]
-   [:ref-key RefKey]])
+   [:ref-key LocalRefKey]])
+
+(def RefKey
+  [:and
+   [:vector :any]
+   [:catn
+    [:component-group-name ComponentGroupName]
+    [:component-name [:? ComponentName]]
+    [:deep-ref-path [:* DeepRefPathKey]]]])
 
 (def Ref
   [:catn
    [:ref-type [:enum ::ref]]
    [:ref-key RefKey]])
 
+(def RegistryRefKey
+  [:and
+   [:vector :any]
+   [:catn
+    [:registry-key RegistryKey]
+    [:deep-ref-path [:* DeepRefPathKey]]]])
+
 (def RegistryRef
   [:catn
    [:ref-type [:enum ::registry-ref]]
-   [:ref-key RefKey]])
+   [:ref-key RegistryRefKey]])
 
 (def DonutRef
   [:or Ref LocalRef RegistryRef])

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -152,7 +152,11 @@
 
 
 (def RefKey
-  [:vector {:min 1} keyword?])
+  [:and
+   [:vector :any]
+   [:cat
+    keyword?
+    [:* [:or keyword? string? symbol?]]]])
 
 (def LocalRef
   [:catn

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -328,8 +328,8 @@
 
 (defn registry-ref->ref
   [system registry-key]
-  (if-let [component-id (get-in system [::registry registry-key])]
-    (ref component-id)
+  (if-let [component-id (get-in system [::registry (first registry-key)])]
+    (ref (into component-id (rest registry-key)))
     (throw (ex-info ":donut.system/registry does not contain registry-key
 Your system should have the key :donut.system/registry, with keywords as keys and valid component paths as values."
                     {:registry-key          registry-key

--- a/src/donut/system/test/mock.clj
+++ b/src/donut/system/test/mock.clj
@@ -23,7 +23,7 @@
                         (return)
                         return))))
         :config {:return     nil
-                 :mock-calls (ds/registry-ref ::mock-calls)}})
+                 :mock-calls (ds/registry-ref [::mock-calls])}})
 
 (defn called?
   "check that a component fn was called at all"

--- a/test/donut/system_test.cljc
+++ b/test/donut/system_test.cljc
@@ -104,6 +104,16 @@
                                                      :config {:port (ds/ref [:env :http :port])}}}}}
                (ds/signal ::ds/start)
                (select-keys [::ds/instances])))))
+  (testing "Refs can contain symbols and strings"
+    (is (= #::ds{:instances {:env {:http {"host" "localhost" 'port 9090}}
+                             :app {:http-server {:host "localhost" :port 9090}}}}
+           (-> #::ds{:defs {:env {:http {"host" "localhost" 'port 9090}}
+                            :app {:http-server #::ds{:start #(::ds/config %)
+                                                       ;; [:env :http 'port] reaches into the :http "component"
+                                                     :config {:host (ds/ref [:env :http "host"])
+                                                              :port (ds/ref [:env :http 'port])}}}}}
+               (ds/signal ::ds/start)
+               (select-keys [::ds/instances])))))
   (testing "components with deep refs are started in the correct order"
     (let [vref-comp (fn [comp-name]
                       #::ds{:config {:ref (ds/ref [:group comp-name :v])}


### PR DESCRIPTION
Strings are useful as map keys because some common data, such as domain names or ARNs, have formatting characters that make them invalid keywords. (Creating manually with clojure.core/keyword still usually works for legacy reasons, but is discouraged). I added symbols as well because it is very easy to, and AFAIK symbols are generally expected to work where keywords do.

- Registry refs used an unwrapped syntax that didn't match their schema. I updated them to use the same vector syntax as other refs and added deep ref support.
- Added a check against the ref schema in the ref creation functions.
- Allow strings and symbols in the deep ref portion of the ref-key schemas.