### PR TITLE
Fix ref resolution errors after a component sends to ->error

### DIFF
--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -640,7 +640,7 @@ Your system should have the key :donut.system/registry, with keywords as keys an
   [system]
   (-> system
       ::out
-      (select-keys [:errors :validation])
+      (select-keys [:error :validation])
       empty?))
 
 ;; copied from loom.graph to work around its bizarre cljs (:in g) issue


### PR DESCRIPTION
The previous behavior: https://clojurians.slack.com/archives/C030C4Z2W0Y/p1691331501961929?thread_ts=1691268317.317879&cid=C030C4Z2W0Y

1. Component A starts, but there's a failure. You send that to the ->error channel
2. Component B starts. Component B references Component A. There's a ref resolution error

The intended behavior is that when a component sends to ->error, signals will not be sent to components that reference the failed component.

This takes @flyingmachine's fix from #19 and adds tests for both ->error and ->validation short-circuiting.