### PR TITLE
Throw an exception when the component graph contains a cycle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Allow strings and symbols in deep ref paths.
+- Throw an exception when the component graph contains a cycle.
 
 
 ## 2022-06-25 0.0.165

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -594,7 +594,10 @@ Your system should have the key :donut.system/registry, with keywords as keys an
   for the given signal"
   [system signal order]
   (let [component-graph        (get-in system [::graphs order])
-        {:keys [pre post]} (handler-lifecycle-names signal)]
+        {:keys [pre post]} (handler-lifecycle-names signal)
+        sorted-graph (la/topsort component-graph)]
+    (when-not sorted-graph
+      (throw (ex-info "Cycle detected" {})))
     (reduce (fn [computation-graph component-node]
               (let [;; generate nodes and edges just for the lifecycle of this
                     ;; component's signal handler
@@ -610,7 +613,7 @@ Your system should have the key :donut.system/registry, with keywords as keys an
                         computation-graph
                         successors)))
             (lg/digraph)
-            (la/topsort component-graph))))
+            sorted-graph)))
 
 (defn- init-signal-computation-graph
   [system signal]

--- a/test/donut/system_test.cljc
+++ b/test/donut/system_test.cljc
@@ -348,6 +348,24 @@
        (ds/signal {::ds/defs {:group {:component {:ref (ds/ref [:nonexistent])}}}}
                   ::ds/start))))
 
+(deftest ref-cycle-test
+  (is (thrown-with-msg?
+       #?(:clj clojure.lang.ExceptionInfo
+          :cljs js/Object)
+       #"Cycle"
+       (ds/signal {::ds/defs {:group-a {:foo (ds/ref [:group-b :component])}
+                              :group-b {:component {:foo (ds/ref [:group-a :foo])}}}}
+                  ::ds/start)))
+
+  (is (thrown-with-msg?
+       #?(:clj clojure.lang.ExceptionInfo
+          :cljs js/Object)
+       #"Cycle"
+       (ds/signal {::ds/defs {:group-a {:foo (ds/ref [:group-b :component])
+                                        :bar (ds/ref [:group-a :foo])}
+                              :group-b {:component {:foo (ds/ref [:group-a :bar])}}}}
+                  ::ds/start))))
+
 (defmethod ds/named-system ::system-config-test
   [_]
   {::ds/defs {:group {:component-a 1


### PR DESCRIPTION
When the system contains a cycle, signals are not sent to any components (because `topsort` returns `nil`). This is pretty confusing, so we can help users by detecting this case and throwing an exception.

In the future I would like to add the actual cycle path and maybe check for self-references.