### PR TITLE
Add note about component nesting to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ functions are where you specify a component's behavior.
 **NB:** You cannot arbitrarily nest components. The top-level keys in the
 `::ds/defs` map name component groups, and the keys in those maps name
 component definitions. All of the `donut.system` signal handlers must be in
-top-level component maps, or they will be ignored. So, for example, this signal
+component definition maps, or they will be ignored. So, for example, this signal
 handler will work: `{::ds/defs {:app {:printer #::ds{:start (fn [_] ...)}}}}` but
 this one will not: `{::ds/defs {:app {:printer {:office #::ds{:start (fn [_] ...)}}}}}`.
 In the second example, the `::ds/start` key and its fn value will appear as-is in

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ top-level component maps, or they will be ignored. So, for example, this signal
 handler will work: `{::ds/defs {:app {:printer #::ds{:start (fn [_] ...)}}}}` but
 this one will not: `{::ds/defs {:app {:printer {:office #::ds{:start (fn [_] ...)}}}}}`.
 In the second example, the `::ds/start` key and its fn value will appear as-is in
-the started system instance.
+the started system instance because it's nested under an additional `:office` key.
 
 Let's actually interact with this system and see its behavior: 
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ These keys are names of _signal handlers_, which you'll learn about momentarily.
 `::ds/start` and `::ds/stop` are both associated with a function. These
 functions are where you specify a component's behavior.
 
+**NB:** You cannot arbitrarily nest components. The top-level keys in the
+`::ds/defs` map name component groups, and the keys in those maps name
+component definitions. All of the `donut.system` signal handlers must be in
+top-level component maps, or they will be ignored. So, for example, this signal
+handler will work: `{::ds/defs {:app {:printer #::ds{:start (fn [_] ...)}}}}` but
+this one will not: `{::ds/defs {:app {:printer {:office #::ds{:start (fn [_] ...)}}}}}`.
+In the second example, the `::ds/start` key and its fn value will appear as-is in
+the started system instance.
+
 Let's actually interact with this system and see its behavior: 
 
 ``` clojure


### PR DESCRIPTION
I wanted to more explicitly call out the need to have components at the correct nesting level in system defs.

Let me know if you want me to change the language or location of the note.