### PR TITLE
Goodbye channel fns, hello component-meta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
             - ./
   deploy:
     docker:
+      # - image: cimg/clojure:1.11.1-openjdk-8.0-node # TODO
       - image: circleci/clojure:openjdk-8-tools-deps-buster-node
     steps:
       - checkout

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
          metosin/malli               {:mvn/version "0.14.0"}
          org.clojure/clojure         {:mvn/version "1.10.3"}
          org.clojure/tools.namespace {:mvn/version "1.3.0"}
-         party.donut/error           {:mvn/version "0.0.11"}}
+         party.donut/error           {:mvn/version "0.0.16"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
          metosin/malli               {:mvn/version "0.14.0"}
          org.clojure/clojure         {:mvn/version "1.10.3"}
          org.clojure/tools.namespace {:mvn/version "1.3.0"}
-         party.donut/error           {:local/root "../error"}}
+         party.donut/error           {:mvn/version "0.0.11"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps  {org.clojure/clojure         {:mvn/version "1.10.3"}
          org.clojure/tools.namespace {:mvn/version "1.3.0"}
          aysylu/loom                 {:mvn/version "1.0.2"}
-         metosin/malli               {:mvn/version "0.7.5"}}
+         metosin/malli               {:mvn/version "0.14.0"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,15 @@
 {:paths ["src" "resources"]
- :deps  {org.clojure/clojure         {:mvn/version "1.10.3"}
+ :deps  {aysylu/loom                 {:mvn/version "1.0.2"}
+         metosin/malli               {:mvn/version "0.14.0"}
+         org.clojure/clojure         {:mvn/version "1.10.3"}
          org.clojure/tools.namespace {:mvn/version "1.3.0"}
-         aysylu/loom                 {:mvn/version "1.0.2"}
-         metosin/malli               {:mvn/version "0.14.0"}}
+         party.donut/error           {:local/root "../error"}}
 
  :aliases
  {:dev
-  {:extra-deps  {ring/ring     {:mvn/version "1.9.4"}
-                 djblue/portal {:mvn/version "0.35.1"}}
+  {:extra-deps  {djblue/portal     {:mvn/version "0.35.1"}
+                 party.donut/error {:local/root "../error"}
+                 ring/ring         {:mvn/version "1.9.4"}}
    :extra-paths ["dev" "test"]}
 
   :test

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -52,6 +52,30 @@
   [m configs]
   (assoc-many m [::config] configs))
 
+(defn get-component-facet
+  [system facet [component-group component-name :as component-id]]
+  (or (flat-get-in system [facet  component-id])
+      (when-not (contains? (get-in system [::defs component-group])
+                           component-name)
+        (throw (ex-info "Component not defined" {:component-id component-id})))))
+
+(defn instance
+  "Get a specific component instance. With no arguments returns set of all
+  component names."
+  ([system]
+   (into {}
+         (for [[k m] (::instances system)]
+           [k (set (keys m))])))
+  ([system component-id]
+   (get-component-facet system ::instances component-id)))
+
+(defn component-meta
+  "Get a specific component's system meta. With no arguments returns set of all
+  component names."
+  [system component-id]
+  (get-component-facet system ::component-meta component-id))
+
+
 ;;---
 ;;; specs
 ;;---
@@ -886,19 +910,6 @@
   {::start (fn [{:keys [::system]}]
              (throw (ex-info "Need to define required component"
                              {:component-id (::component-id system)})))})
-
-(defn instance
-  "Get a specific component instance. With no arguments returns set of all
-  component names."
-  ([system]
-   (into {}
-         (for [[k m] (::instances system)]
-           [k (set (keys m))])))
-  ([system [component-group component-name :as component-id]]
-   (or (flat-get-in system [::instances  component-id])
-       (when-not (contains? (get-in system [::defs component-group])
-                            component-name)
-         (throw (ex-info "Component not defined" {:component-id component-id}))))))
 
 (defn component-doc
   [system component-id]

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -617,10 +617,18 @@
         stage-fn     (or (flat-get-in system [::resolved-defs computation-stage-node])
                          system-identity)]
     (fn [system]
-      (let [stage-result (apply-stage-fn system stage-fn component-id)]
-        (if (system? stage-result)
-          stage-result
-          system)))))
+      (if (map? stage-fn)
+        (reduce-kv (fn mapped-lifecycle-fns [system _lifecycle-fn-name lifecycle-fn]
+                     (let [stage-result (apply-stage-fn system lifecycle-fn component-id)]
+                       (if (system? stage-result)
+                         stage-result
+                         system)))
+                   system
+                   stage-fn)
+        (let [stage-result (apply-stage-fn system stage-fn component-id)]
+          (if (system? stage-result)
+            stage-result
+            system))))))
 
 (defn- handler-stage-fn
   "returns function for a handler (e.g. ::start) as opposed to a lifecycle

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -3,6 +3,7 @@
   (:require
    [clojure.walk :as walk]
    [clojure.zip :as zip]
+   [donut.error :as de]
    [donut.system.plugin :as dsp]
    [loom.alg :as la]
    [loom.derived :as ld]
@@ -215,10 +216,7 @@
 (def ref-type (fn [v] (when (seqable? v) (first v))))
 
 (defn- ensure-valid-ref [ref]
-  (when-let [explanation (m/explain DonutRef ref)]
-    (throw (ex-info (str "Invalid ref: " (pr-str ref))
-                    {:spec-explain-human (me/humanize explanation)
-                     :spec-explain       explanation})))
+  (de/validate! DonutRef ref (str "Invalid ref:" (pr-str ref)))
   ref)
 
 (defn ref [k] (ensure-valid-ref [::ref k]))
@@ -795,11 +793,10 @@
 
 (defn signal
   [system signal-name]
-  (when-let [explanation (m/explain DonutSystem system)]
-    (throw (ex-info "Invalid system"
-                    {:reason             :system-spec-validation-error
-                     :spec-explain-human (me/humanize explanation)
-                     :spec-explain       explanation})))
+  (de/validate! DonutSystem
+                system
+                {::de/id ::invalid-system
+                 ::de/url (de/url ::invalid-system)})
 
   (let [inited-system (init-system system signal-name)]
     (when-let [explanation (m/explain (into [:enum] (->> inited-system ::signals keys))

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -726,10 +726,11 @@
       ;; let donut.system exceptions flow through
       throwable
       (ex-info (str "Error on " computation-stage " when applying signal")
-               {:component-id   (vec (take 2 computation-stage))
-                :signal-handler (last computation-stage)
-                ::system        system
-                :message        message}
+               (with-meta
+                 {:component-id   (vec (take 2 computation-stage))
+                  :signal-handler (last computation-stage)
+                  :message        message}
+                 {::system system})
                throwable))))
 
 (defn- apply-signal-stage
@@ -912,7 +913,7 @@
   "Will attempt to stop a system that threw an exception when starting"
   ([] (stop-failed-system *e))
   ([e]
-   (when-let [system (and e (::system (ex-data e)))]
+   (when-let [system (and e (::system (meta (ex-data e))))]
      (stop system))))
 
 ;;---

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -724,7 +724,7 @@
   "provide a more specific exception for signal application to help narrow down the source of the exception"
   [system computation-stage throwable]
   (let [message #?(:clj (.getMessage throwable)
-                   :cljs (. t -message))]
+                   :cljs (. throwable -message))]
     (if (re-find #"^:donut.system" message)
       ;; let donut.system exceptions flow through
       throwable

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -78,7 +78,7 @@
 
 
 ;;---
-;;; specs
+;;; schemas
 ;;---
 
 (def default-signals
@@ -177,7 +177,7 @@
 (def system? (m/validator DonutSystem))
 
 (def DeepRefPathKey
-  [:or keyword? string? symbol?])
+  [:or keyword? string? symbol? nat-int?])
 
 (def LocalRefKey
   [:and

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -618,6 +618,7 @@
                          system-identity)]
     (fn [system]
       (if (map? stage-fn)
+        ;; lifecycle fns can be a map to allow more than one
         (reduce-kv (fn mapped-lifecycle-fns [system _lifecycle-fn-name lifecycle-fn]
                      (let [stage-result (apply-stage-fn system lifecycle-fn component-id)]
                        (if (system? stage-result)

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -3,7 +3,6 @@
   (:require
    [clojure.walk :as walk]
    [clojure.zip :as zip]
-   [donut.error :as de]
    [donut.system.plugin :as dsp]
    [loom.alg :as la]
    [loom.derived :as ld]

--- a/src/donut/system/dev.cljc
+++ b/src/donut/system/dev.cljc
@@ -1,6 +1,8 @@
 (ns donut.system.dev
   (:require
    [donut.error :as de]
+   [donut.error.dev :as ded]
+   [donut.system.validation :as dsv]
    [malli.dev.virhe :as v]))
 
 ;;---
@@ -10,12 +12,29 @@
 (defn signal-meta-block
   [{:keys [:donut.system/signal-meta]} printer]
   (when signal-meta
-    [(de/-block "donut.system signal handling metadata" (v/-visit signal-meta printer) printer)]))
+    [(ded/-block "donut.system signal handling metadata" (v/-visit signal-meta printer) printer)]))
 
 (defmethod v/-format ::apply-signal-exception
   [_ {:keys [message] :as data} printer]
   {:title "Error Applying Signal for Component"
    :body  (de/build-group
            [(de/-block "Exception message" message printer)]
+           (signal-meta-block data printer)
+           (de/donut-footer data printer))})
+
+(defmethod v/-format ::dsv/invalid-component-config [_ {:keys [schema-path config-path explanation] :as data} printer]
+  {:title "Component Config Validation Error"
+   :body  (de/build-group
+           (de/schema-explain-body explanation printer)
+           [(de/-block "Schema path" (v/-visit schema-path printer) printer)]
+           [(de/-block "Config path" (v/-visit config-path printer) printer)]
+           (signal-meta-block data printer)
+           (de/donut-footer data printer))})
+
+(defmethod v/-format ::dsv/invalid-instance [_ {:keys [schema-path explanation] :as data} printer]
+  {:title "Component Instance Validation Error"
+   :body  (de/build-group
+           (de/schema-explain-body explanation printer)
+           [(de/-block "Schema path" (v/-visit schema-path printer) printer)]
            (signal-meta-block data printer)
            (de/donut-footer data printer))})

--- a/src/donut/system/dev.cljc
+++ b/src/donut/system/dev.cljc
@@ -1,0 +1,21 @@
+(ns donut.system.dev
+  (:require
+   [donut.error :as de]
+   [malli.dev.virhe :as v]))
+
+;;---
+;; error reporting
+;;---
+
+(defn signal-meta-block
+  [{:keys [:donut.system/signal-meta]} printer]
+  (when signal-meta
+    [(de/-block "donut.system signal handling metadata" (v/-visit signal-meta printer) printer)]))
+
+(defmethod v/-format ::apply-signal-exception
+  [_ {:keys [message] :as data} printer]
+  {:title "Error Applying Signal for Component"
+   :body  (de/build-group
+           [(de/-block "Exception message" message printer)]
+           (signal-meta-block data printer)
+           (de/donut-footer data printer))})

--- a/src/donut/system/dev.cljc
+++ b/src/donut/system/dev.cljc
@@ -1,7 +1,7 @@
 (ns donut.system.dev
   (:require
-   [donut.error :as de]
    [donut.error.dev :as ded]
+   [donut.system :as ds]
    [donut.system.validation :as dsv]
    [malli.dev.virhe :as v]))
 
@@ -14,27 +14,34 @@
   (when signal-meta
     [(ded/-block "donut.system signal handling metadata" (v/-visit signal-meta printer) printer)]))
 
-(defmethod v/-format ::apply-signal-exception
+(defmethod v/-format ::ds/apply-signal-exception
   [_ {:keys [message] :as data} printer]
   {:title "Error Applying Signal for Component"
-   :body  (de/build-group
-           [(de/-block "Exception message" message printer)]
+   :body  (ded/build-group
+           [(ded/-block "Exception message" message printer)]
            (signal-meta-block data printer)
-           (de/donut-footer data printer))})
+           (ded/donut-footer data printer))})
+
+(defmethod v/-format ::ds/invalid-system
+  [_ {:keys [explanation] :as data} printer]
+  {:title "System doesn't match schema"
+   :body  (ded/build-group
+           (ded/schema-explain-body explanation printer)
+           (ded/donut-footer data printer))})
 
 (defmethod v/-format ::dsv/invalid-component-config [_ {:keys [schema-path config-path explanation] :as data} printer]
   {:title "Component Config Validation Error"
-   :body  (de/build-group
-           (de/schema-explain-body explanation printer)
-           [(de/-block "Schema path" (v/-visit schema-path printer) printer)]
-           [(de/-block "Config path" (v/-visit config-path printer) printer)]
+   :body  (ded/build-group
+           (ded/schema-explain-body explanation printer)
+           [(ded/-block "Schema path" (v/-visit schema-path printer) printer)]
+           [(ded/-block "Config path" (v/-visit config-path printer) printer)]
            (signal-meta-block data printer)
-           (de/donut-footer data printer))})
+           (ded/donut-footer data printer))})
 
 (defmethod v/-format ::dsv/invalid-instance [_ {:keys [schema-path explanation] :as data} printer]
   {:title "Component Instance Validation Error"
-   :body  (de/build-group
-           (de/schema-explain-body explanation printer)
-           [(de/-block "Schema path" (v/-visit schema-path printer) printer)]
+   :body  (ded/build-group
+           (ded/schema-explain-body explanation printer)
+           [(ded/-block "Schema path" (v/-visit schema-path printer) printer)]
            (signal-meta-block data printer)
-           (de/donut-footer data printer))})
+           (ded/donut-footer data printer))})

--- a/src/donut/system/validation.cljc
+++ b/src/donut/system/validation.cljc
@@ -11,6 +11,7 @@
            (de/schema-explain-body explanation printer)
            [(de/-block "Schema path" (v/-visit schema-path printer) printer)]
            [(de/-block "Config path" (v/-visit config-path printer) printer)]
+           (ds/signal-meta-block data printer)
            (de/donut-footer data printer))})
 
 (defmethod v/-format ::invalid-instance [_ {:keys [schema-path explanation] :as data} printer]
@@ -18,6 +19,7 @@
    :body  (de/build-group
            (de/schema-explain-body explanation printer)
            [(de/-block "Schema path" (v/-visit schema-path printer) printer)]
+           (ds/signal-meta-block data printer)
            (de/donut-footer data printer))})
 
 (defn validate-config
@@ -26,10 +28,11 @@
     (de/validate!
      config-schema
      config
-     {::de/id      ::invalid-component-config
-      ::de/url     (de/url ::invalid-component-config)
-      :schema-path (into [::ds/defs] (conj component-id ::ds/config-schema))
-      :config-path (into [::ds/defs] (conj component-id ::ds/config))})))
+     {::de/id          ::invalid-component-config
+      ::de/url         (de/url ::invalid-component-config)
+      ::ds/signal-meta {:component-id component-id}
+      :schema-path     (into [::ds/defs] (conj component-id ::ds/config-schema))
+      :config-path     (into [::ds/defs] (conj component-id ::ds/config))})))
 
 (defn validate-instance
   [{:keys [::ds/instance ::ds/instance-schema ::ds/component-id]}]
@@ -37,9 +40,10 @@
     (de/validate!
      instance-schema
      instance
-     {::de/id      ::invalid-instance
-      ::de/url     (de/url ::invalid-instance)
-      :schema-path (into [::ds/defs] (conj component-id ::ds/instance-schema))})))
+     {::de/id          ::invalid-instance
+      ::de/url         (de/url ::invalid-instance)
+      ::ds/signal-meta {:component-id component-id}
+      :schema-path     (into [::ds/defs] (conj component-id ::ds/instance-schema))})))
 
 (def validation-plugin
   #::dsp{:name

--- a/src/donut/system/validation.cljc
+++ b/src/donut/system/validation.cljc
@@ -2,26 +2,7 @@
   (:require
    [donut.error :as de]
    [donut.system :as ds]
-   [donut.system.dev :as dev]
-   [donut.system.plugin :as dsp]
-   [malli.dev.virhe :as v]))
-
-(defmethod v/-format ::invalid-component-config [_ {:keys [schema-path config-path explanation] :as data} printer]
-  {:title "Component Config Validation Error"
-   :body  (de/build-group
-           (de/schema-explain-body explanation printer)
-           [(de/-block "Schema path" (v/-visit schema-path printer) printer)]
-           [(de/-block "Config path" (v/-visit config-path printer) printer)]
-           (dev/signal-meta-block data printer)
-           (de/donut-footer data printer))})
-
-(defmethod v/-format ::invalid-instance [_ {:keys [schema-path explanation] :as data} printer]
-  {:title "Component Instance Validation Error"
-   :body  (de/build-group
-           (de/schema-explain-body explanation printer)
-           [(de/-block "Schema path" (v/-visit schema-path printer) printer)]
-           (dev/signal-meta-block data printer)
-           (de/donut-footer data printer))})
+   [donut.system.plugin :as dsp]))
 
 (defn signal-meta
   [{:keys [::ds/component-id ::ds/system]}]

--- a/src/donut/system/validation.cljc
+++ b/src/donut/system/validation.cljc
@@ -6,10 +6,10 @@
    [malli.error :as me]))
 
 (defn validate
-  [schema x scheme-key]
+  [schema x schema-key]
   (when-let [explanation (and schema (m/explain schema x))]
-    (throw (ex-info "scheme found invalid component data"
-                    {:scheme-key         scheme-key
+    (throw (ex-info "schema found invalid component data"
+                    {:schema-key         schema-key
                      :spec-explain-human (me/humanize explanation)
                      :spec-explain       explanation}))))
 

--- a/src/donut/system/validation.cljc
+++ b/src/donut/system/validation.cljc
@@ -3,48 +3,43 @@
    [donut.error :as de]
    [donut.system :as ds]
    [donut.system.plugin :as dsp]
-   [malli.core :as m]
-   [malli.dev.virhe :as v]
-   [malli.error :as me]))
+   [malli.dev.virhe :as v]))
 
-(defn- common-format-body
-  [{:keys [explanation schema-path]} printer]
-  [:group
-   (v/-block "Value" (v/-visit (me/error-value explanation printer) printer) printer) :break :break
-   (v/-block "Errors" (v/-visit (me/humanize (me/with-spell-checking explanation)) printer) printer) :break :break
-   (v/-block "Schema" (v/-visit (:schema explanation) printer) printer) :break :break
-   (v/-block "Schema path" (v/-visit schema-path printer) printer)])
-
-(defmethod v/-format ::invalid-component-config [_ {:keys [value-path] :as data} printer]
+(defmethod v/-format ::invalid-component-config [_ {:keys [schema-path explanation] :as data} printer]
   {:title "Component Config Validation Error"
-   :body (into (common-format-body data printer)
-               [:break :break
-                (v/-block "Config path" (v/-visit value-path printer) printer)])})
+   :body  (de/build-group
+           (de/schema-explain-body explanation printer)
+           [(de/-block "Schema path" (v/-visit schema-path printer) printer)]
+           (de/donut-footer data printer))})
 
-(defmethod v/-format ::invalid-instance [_ data printer]
+(defmethod v/-format ::invalid-instance [_ {:keys [schema-path config-path explanation] :as data} printer]
   {:title "Component Instance Validation Error"
-   :body  (common-format-body data printer)})
-
-(defn validate
-  [{:keys [type schema value] :as data}]
-
-  (when-let [explanation (and schema (m/explain schema value))]
-    (m/-fail! type
-              (-> (dissoc data :type :schema :value)
-                  (assoc :explanation explanation)))))
+   :body  (de/build-group
+           (de/schema-explain-body explanation printer)
+           [(de/-block "Schema path" (v/-visit schema-path printer) printer)]
+           [(de/-block "config path" (v/-visit config-path printer) printer)]
+           (de/donut-footer data printer))})
 
 (defn validate-config
   [{:keys [::ds/config-schema ::ds/config ::ds/component-id] :as _component-def}]
   (when config-schema
-    (de/validate! config-schema config
-      {:schema-path (into [::ds/defs] (conj component-id ::ds/config-schema))
-       :value-path  (into [::ds/defs] (conj component-id ::ds/config))})))
+    (de/validate!
+     config-schema
+     config
+     {::de/id      ::invalid-component-config
+      ::de/url     (de/url ::invalid-component-config)
+      :schema-path (into [::ds/defs] (conj component-id ::ds/config-schema))
+      :config-path (into [::ds/defs] (conj component-id ::ds/config))})))
 
 (defn validate-instance
   [{:keys [::ds/instance ::ds/instance-schema ::ds/component-id]}]
   (when instance-schema
-    (de/validate! instance-schema instance
-      {:schema-path (into [::ds/defs] (conj component-id ::ds/config-schema))})))
+    (de/validate!
+     instance-schema
+     instance
+     {::de/id      ::invalid-instance
+      ::de/url     (de/url ::invalid-instance)
+      :schema-path (into [::ds/defs] (conj component-id ::ds/config-schema))})))
 
 (def validation-plugin
   #::dsp{:name

--- a/src/donut/system/validation.cljc
+++ b/src/donut/system/validation.cljc
@@ -5,19 +5,19 @@
    [donut.system.plugin :as dsp]
    [malli.dev.virhe :as v]))
 
-(defmethod v/-format ::invalid-component-config [_ {:keys [schema-path explanation] :as data} printer]
+(defmethod v/-format ::invalid-component-config [_ {:keys [schema-path config-path explanation] :as data} printer]
   {:title "Component Config Validation Error"
    :body  (de/build-group
            (de/schema-explain-body explanation printer)
            [(de/-block "Schema path" (v/-visit schema-path printer) printer)]
+           [(de/-block "Config path" (v/-visit config-path printer) printer)]
            (de/donut-footer data printer))})
 
-(defmethod v/-format ::invalid-instance [_ {:keys [schema-path config-path explanation] :as data} printer]
+(defmethod v/-format ::invalid-instance [_ {:keys [schema-path explanation] :as data} printer]
   {:title "Component Instance Validation Error"
    :body  (de/build-group
            (de/schema-explain-body explanation printer)
            [(de/-block "Schema path" (v/-visit schema-path printer) printer)]
-           [(de/-block "config path" (v/-visit config-path printer) printer)]
            (de/donut-footer data printer))})
 
 (defn validate-config
@@ -39,7 +39,7 @@
      instance
      {::de/id      ::invalid-instance
       ::de/url     (de/url ::invalid-instance)
-      :schema-path (into [::ds/defs] (conj component-id ::ds/config-schema))})))
+      :schema-path (into [::ds/defs] (conj component-id ::ds/instance-schema))})))
 
 (def validation-plugin
   #::dsp{:name

--- a/src/donut/system/validation.cljc
+++ b/src/donut/system/validation.cljc
@@ -13,17 +13,13 @@
                      :spec-explain-human (me/humanize explanation)
                      :spec-explain       explanation}))))
 
-(defn validate-def-pre-start
-  [{:keys [::ds/pre-start-schema] :as component-def}]
-  (validate pre-start-schema component-def ::ds/pre-start-schema))
+(defn validate-config
+  [{:keys [::ds/config-schema ::ds/config] :as _component-def}]
+  (validate config-schema config ::ds/config-schema))
 
 (defn validate-instance
   [{:keys [::ds/instance ::ds/instance-schema]}]
   (validate instance-schema instance ::ds/instance-schema))
-
-(defn validate-config
-  [{:keys [::ds/config-schema ::ds/config] :as _component-def}]
-  (validate config-schema config ::ds/config-schema))
 
 (def validation-plugin
   #::dsp{:name
@@ -33,6 +29,5 @@
          "Updates pre-start and post-start to validate configs and instances"
 
          :system-defaults
-         {::ds/base {::ds/pre-start  {::validate-pre-start validate-def-pre-start
-                                      ::validate-config    validate-config}
+         {::ds/base {::ds/pre-start  {::validate-config validate-config}
                      ::ds/post-start {::validate validate-instance}}}})

--- a/src/donut/system/validation.cljc
+++ b/src/donut/system/validation.cljc
@@ -6,37 +6,45 @@
    [malli.dev.virhe :as v]
    [malli.error :as me]))
 
+(defn- common-format-body
+  [{:keys [explanation schema-path value-path]} printer]
+  [:group
+   (v/-block "Value" (v/-visit (me/error-value explanation printer) printer) printer) :break :break
+   (v/-block "Errors" (v/-visit (me/humanize (me/with-spell-checking explanation)) printer) printer) :break :break
+   (v/-block "Schema" (v/-visit (:schema explanation) printer) printer) :break :break
+   (v/-block "Schema path" (v/-visit schema-path printer) printer)])
 
-(defmethod v/-format ::invalid [_ {:keys [explanation schema-path value-path] :as data} printer]
-  {:title "System Validation Error"
-   :body  [:group
-           (v/-block "Value" (v/-visit (me/error-value explanation printer) printer) printer) :break :break
-           (v/-block "Errors" (v/-visit (me/humanize (me/with-spell-checking explanation)) printer) printer) :break :break
-           (v/-block "Schema" (v/-visit (:schema explanation) printer) printer) :break :break
-           (v/-block "Schema path" (v/-visit schema-path printer) printer) :break :break
-           (v/-block "Value path" (v/-visit value-path printer) printer)]})
+(defmethod v/-format ::invalid-component-config [_ {:keys [value-path] :as data} printer]
+  {:title "Component Config Validation Error"
+   :body (into (common-format-body data printer)
+               [:break :break
+                (v/-block "Config path" (v/-visit value-path printer) printer)])})
+
+(defmethod v/-format ::invalid-instance [_ data printer]
+  {:title "Component Instance Validation Error"
+   :body  (common-format-body data printer)})
 
 (defn validate
-  [{:keys [schema schema-path value value-path]}]
+  [{:keys [type schema value] :as data}]
   (when-let [explanation (and schema (m/explain schema value))]
-    (m/-fail! ::invalid
-              {:explanation explanation
-               :schema-path schema-path
-               :value-path  value-path})))
+    (m/-fail! type
+              (-> (dissoc data :type :schema :value)
+                  (assoc :explanation explanation)))))
 
 (defn validate-config
   [{:keys [::ds/config-schema ::ds/config ::ds/component-id] :as _component-def}]
-  (validate {:schema      config-schema
+  (validate {:type        ::invalid-component-config
+             :schema      config-schema
              :schema-path (into [::ds/defs] (conj component-id ::ds/config-schema))
              :value       config
              :value-path  (into [::ds/defs] (conj component-id ::ds/config))}))
 
 (defn validate-instance
   [{:keys [::ds/instance ::ds/instance-schema ::ds/component-id]}]
-  (validate {:schema      instance-schema
+  (validate {:type        ::invalid-instance
+             :schema      instance-schema
              :schema-path (into [::ds/defs] (conj component-id ::ds/instance-schema))
-             :value       instance
-             :value-path  (into [::ds/instances] component-id)}))
+             :value       instance}))
 
 (def validation-plugin
   #::dsp{:name

--- a/src/donut/system/validation.cljc
+++ b/src/donut/system/validation.cljc
@@ -3,23 +3,40 @@
    [donut.system :as ds]
    [donut.system.plugin :as dsp]
    [malli.core :as m]
+   [malli.dev.virhe :as v]
    [malli.error :as me]))
 
+
+(defmethod v/-format ::invalid [_ {:keys [explanation schema-path value-path] :as data} printer]
+  {:title "System Validation Error"
+   :body  [:group
+           (v/-block "Value" (v/-visit (me/error-value explanation printer) printer) printer) :break :break
+           (v/-block "Errors" (v/-visit (me/humanize (me/with-spell-checking explanation)) printer) printer) :break :break
+           (v/-block "Schema" (v/-visit (:schema explanation) printer) printer) :break :break
+           (v/-block "Schema path" (v/-visit schema-path printer) printer) :break :break
+           (v/-block "Value path" (v/-visit value-path printer) printer)]})
+
 (defn validate
-  [schema x schema-key]
-  (when-let [explanation (and schema (m/explain schema x))]
-    (throw (ex-info "schema found invalid component data"
-                    {:schema-key         schema-key
-                     :spec-explain-human (me/humanize explanation)
-                     :spec-explain       explanation}))))
+  [{:keys [schema schema-path value value-path]}]
+  (when-let [explanation (and schema (m/explain schema value))]
+    (m/-fail! ::invalid
+              {:explanation explanation
+               :schema-path schema-path
+               :value-path  value-path})))
 
 (defn validate-config
-  [{:keys [::ds/config-schema ::ds/config] :as _component-def}]
-  (validate config-schema config ::ds/config-schema))
+  [{:keys [::ds/config-schema ::ds/config ::ds/component-id] :as _component-def}]
+  (validate {:schema      config-schema
+             :schema-path (into [::ds/defs] (conj component-id ::ds/config-schema))
+             :value       config
+             :value-path  (into [::ds/defs] (conj component-id ::ds/config))}))
 
 (defn validate-instance
-  [{:keys [::ds/instance ::ds/instance-schema]}]
-  (validate instance-schema instance ::ds/instance-schema))
+  [{:keys [::ds/instance ::ds/instance-schema ::ds/component-id]}]
+  (validate {:schema      instance-schema
+             :schema-path (into [::ds/defs] (conj component-id ::ds/instance-schema))
+             :value       instance
+             :value-path  (into [::ds/instances] component-id)}))
 
 (def validation-plugin
   #::dsp{:name

--- a/test/donut/system/validation_test.cljc
+++ b/test/donut/system/validation_test.cljc
@@ -6,26 +6,6 @@
    [donut.system.validation :as dsv]
    [malli.core :as m]))
 
-(deftest component-def-schema-validation-test
-  (testing "use ::ds/pre-start-schema to validate entire component def"
-    (let [system  #::ds{:defs
-                        {:group-a
-                         {:component-a
-                          #::ds{:start            (fn [_] 1)
-                                :config           {}
-                                :pre-start-schema [:map [::ds/config map?]]}}}
-                        :plugins
-                        [dsv/validation-plugin]}
-          thrown? (atom false)]
-      (try (ds/start system {[:group-a :component-a ::ds/config] "not a map"})
-           (catch #?(:clj clojure.lang.ExceptionInfo
-                     :cljs js/Object)
-               e
-             (is (= "scheme found invalid component data"
-                    (-> e ex-data :message)))
-             (reset! thrown? true)))
-      (ds/start system))))
-
 (deftest instance-schema-validation-test
   (testing "use ::ds/instance-schema to validate instance returned by ::ds/start"
     (let [system #::ds{:defs
@@ -42,7 +22,7 @@
            (catch #?(:clj clojure.lang.ExceptionInfo
                      :cljs js/Object)
                e
-             (is (= "scheme found invalid component data"
+             (is (= "schema found invalid component data"
                     (-> e ex-data :message)))
              (reset! thrown? true)))
 
@@ -64,7 +44,7 @@
            (catch #?(:clj clojure.lang.ExceptionInfo
                      :cljs js/Object)
                e
-             (is (= "scheme found invalid component data"
+             (is (= "schema found invalid component data"
                     (-> e ex-data :message)))
              (reset! thrown? true)))
       ;; satisfy spec

--- a/test/donut/system/validation_test.cljc
+++ b/test/donut/system/validation_test.cljc
@@ -22,10 +22,11 @@
            (catch #?(:clj clojure.lang.ExceptionInfo
                      :cljs js/Object)
                e
-             (is (= "schema found invalid component data"
+             (is (= ":donut.system.validation/invalid"
                     (-> e ex-data :message)))
              (reset! thrown? true)))
-
+      (is @thrown?)
+      ;; satisfy spec
       (ds/start system))))
 
 (deftest config-schema-validation-test
@@ -44,8 +45,9 @@
            (catch #?(:clj clojure.lang.ExceptionInfo
                      :cljs js/Object)
                e
-             (is (= "schema found invalid component data"
+             (is (= ":donut.system.validation/invalid"
                     (-> e ex-data :message)))
              (reset! thrown? true)))
+      (is @thrown?)
       ;; satisfy spec
       (ds/start system {[:group-a :component-a ::ds/config] 10}))))

--- a/test/donut/system/validation_test.cljc
+++ b/test/donut/system/validation_test.cljc
@@ -22,7 +22,7 @@
            (catch #?(:clj clojure.lang.ExceptionInfo
                      :cljs js/Object)
                e
-             (is (= ":donut.system.validation/invalid"
+             (is (= :donut.system.validation/invalid-instance
                     (-> e ex-data :message)))
              (reset! thrown? true)))
       (is @thrown?)
@@ -45,7 +45,7 @@
            (catch #?(:clj clojure.lang.ExceptionInfo
                      :cljs js/Object)
                e
-             (is (= ":donut.system.validation/invalid"
+             (is (= :donut.system.validation/invalid-component-config
                     (-> e ex-data :message)))
              (reset! thrown? true)))
       (is @thrown?)

--- a/test/donut/system/validation_test.cljc
+++ b/test/donut/system/validation_test.cljc
@@ -22,8 +22,8 @@
            (catch #?(:clj clojure.lang.ExceptionInfo
                      :cljs js/Object)
                e
-             (is (= ":donut.error/schema-validation-error"
-                    (-> e ex-data :message)))
+             (is (= ":donut.system.validation/invalid-component-config"
+                    (ex-message e)))
              (reset! thrown? true)))
       (is @thrown?)
       ;; satisfy spec
@@ -45,8 +45,8 @@
            (catch #?(:clj clojure.lang.ExceptionInfo
                      :cljs js/Object)
                e
-             (is (= :donut.system.validation/invalid-instance
-                    (-> e ex-data :message)))
+             (is (= ":donut.system.validation/invalid-instance"
+                    (ex-message e)))
              (reset! thrown? true)))
       (is @thrown?)
       ;; satisfy spec

--- a/test/donut/system/validation_test.cljc
+++ b/test/donut/system/validation_test.cljc
@@ -8,39 +8,64 @@
 
 (deftest component-def-schema-validation-test
   (testing "use ::ds/pre-start-schema to validate entire component def"
-    (let [system #::ds{:defs
-                       {:group-a
-                        {:component-a
-                         #::ds{:start (fn [_] 1)
-                               :config {}
-                               :pre-start-schema [:map [::ds/config map?]]}}}
-                       :plugins
-                       [dsv/validation-plugin]}]
-      (is (= {::ds/config ["should be a map"]}
-             (-> (ds/start system {[:group-a :component-a ::ds/config] "not a map"})
-                 ::ds/out
-                 :validation
-                 :group-a
-                 :component-a
-                 :spec-explain-human)))
-      (is (nil? (::ds/out (ds/start system)))))))
+    (let [system  #::ds{:defs
+                        {:group-a
+                         {:component-a
+                          #::ds{:start            (fn [_] 1)
+                                :config           {}
+                                :pre-start-schema [:map [::ds/config map?]]}}}
+                        :plugins
+                        [dsv/validation-plugin]}
+          thrown? (atom false)]
+      (try (ds/start system {[:group-a :component-a ::ds/config] "not a map"})
+           (catch #?(:clj clojure.lang.ExceptionInfo
+                     :cljs js/Object)
+               e
+             (is (= "scheme found invalid component data"
+                    (-> e ex-data :message)))
+             (reset! thrown? true)))
+      (ds/start system))))
 
 (deftest instance-schema-validation-test
   (testing "use ::ds/instance-schema to validate instance returned by ::ds/start"
     (let [system #::ds{:defs
                        {:group-a
                         {:component-a
-                         #::ds{:start 1
-                               :config {}
+                         #::ds{:start           1
+                               :config          {}
                                :instance-schema (m/schema int?)}}}
 
                        :plugins
-                       [dsv/validation-plugin]}]
-      (is (= ["should be an int"]
-             (-> (ds/start system {[:group-a :component-a ::ds/start] "not an int"})
-                 ::ds/out
-                 :validation
-                 :group-a
-                 :component-a
-                 :spec-explain-human)))
-      (is (nil? (::ds/out (ds/start system)))))))
+                       [dsv/validation-plugin]}
+          thrown? (atom false)]
+      (try (ds/start system {[:group-a :component-a ::ds/start] "not an int"})
+           (catch #?(:clj clojure.lang.ExceptionInfo
+                     :cljs js/Object)
+               e
+             (is (= "scheme found invalid component data"
+                    (-> e ex-data :message)))
+             (reset! thrown? true)))
+
+      (ds/start system))))
+
+(deftest config-schema-validation-test
+  (testing "use ::ds/instance-schema to validate instance returned by ::ds/start"
+    (let [system #::ds{:defs
+                       {:group-a
+                        {:component-a
+                         #::ds{:start         1
+                               :config        {}
+                               :config-schema (m/schema int?)}}}
+
+                       :plugins
+                       [dsv/validation-plugin]}
+          thrown? (atom false)]
+      (try (ds/start system)
+           (catch #?(:clj clojure.lang.ExceptionInfo
+                     :cljs js/Object)
+               e
+             (is (= "scheme found invalid component data"
+                    (-> e ex-data :message)))
+             (reset! thrown? true)))
+      ;; satisfy spec
+      (ds/start system {[:group-a :component-a ::ds/config] 10}))))

--- a/test/donut/system_test.cljc
+++ b/test/donut/system_test.cljc
@@ -246,7 +246,8 @@
 (deftest subsystem-ref-edges
   (is (= [[[:sub-systems :system-1] [:common-services :job-queue]]
           [[:sub-systems :system-1] [:common-services :db]]
-          [[:sub-systems :system-2] [:common-services]]]
+          [[:sub-systems :system-2] [:common-services :job-queue]]
+          [[:sub-systems :system-2] [:common-services :db]]]
          (#'ds/ref-edges system-with-subsystem :topsort))))
 
 (deftest subsystem-component-nodes-test
@@ -254,16 +255,18 @@
              (lg/add-nodes [:env :app-name])
              (lg/add-edges [[:common-services :job-queue] [:sub-systems :system-1]]
                            [[:common-services :db] [:sub-systems :system-1]]
-                           [[:common-services] [:sub-systems :system-2]]))
+                           [[:common-services :job-queue] [:sub-systems :system-2]]
+                           [[:common-services :db] [:sub-systems :system-2]]))
          (let [graph (#'ds/component-graph-nodes system-with-subsystem)]
            (#'ds/component-graph-add-edges graph system-with-subsystem :reverse-topsort)))))
 
-(deftest subsystem-computation-graph-test
+(deftest subsystem-graph-test
   (is (= (-> (lg/digraph)
              (lg/add-nodes [:env :app-name])
              (lg/add-edges [[:common-services :job-queue] [:sub-systems :system-1]]
                            [[:common-services :db] [:sub-systems :system-1]]
-                           [[:common-services] [:sub-systems :system-2]]))
+                           [[:common-services :job-queue] [:sub-systems :system-2]]
+                           [[:common-services :db] [:sub-systems :system-2]]))
          (-> system-with-subsystem
              (ds/init-system ::ds/start)
              ::ds/graphs

--- a/test/donut/system_test.cljc
+++ b/test/donut/system_test.cljc
@@ -431,7 +431,7 @@
                   ::ds/start)
        (catch #?(:clj Exception :cljs :default) e
          (is (= [:group :component]
-                (:component (ex-data e)))))))
+                (:component-id (ex-data e)))))))
 
 (deftest component-ids-test
   (is (= [[:group-a :a]

--- a/test/donut/system_test.cljc
+++ b/test/donut/system_test.cljc
@@ -438,7 +438,10 @@
                   ::ds/start)
        (catch #?(:clj Exception :cljs :default) e
          (is (= [:group :component]
-                (:component-id (ex-data e)))))))
+                (-> e
+                    ex-data
+                    ::ds/signal-meta
+                    :component-id))))))
 
 (deftest component-ids-test
   (is (= [[:group-a :a]

--- a/test/donut/system_test.cljc
+++ b/test/donut/system_test.cljc
@@ -604,3 +604,13 @@
           (throw (ex-info "test" {})))
         (catch #?(:clj Exception :cljs :default) _))
       (is (= true @stop-check)))))
+
+(deftest component-meta-test
+  (let [system {::ds/defs {:group {:component #::ds{:pre-start  (fn [{:keys [::ds/component-meta]}]
+                                                                  (reset! component-meta [::ds/pre-start]))
+                                                    :start      (fn [{:keys [::ds/component-meta]}]
+                                                                  (swap! component-meta conj ::ds/start))
+                                                    :post-start (fn [{:keys [::ds/component-meta]}]
+                                                                  (swap! component-meta conj ::ds/post-start))}}}}]
+    (is (= [::ds/pre-start ::ds/start ::ds/post-start]
+           (get-in (ds/start system) [::ds/component-meta :group :component])))))

--- a/test/donut/system_test.cljc
+++ b/test/donut/system_test.cljc
@@ -171,29 +171,6 @@
                (ds/signal ::ds/start)
                (select-keys [::ds/instances]))))))
 
-
-(deftest signal-error-short-circuit
-  (is (= #::ds{:out {:error {:env {:http-port {:message "Intentional error"}}}}}
-         (-> #::ds{:defs {:env {:http-port #::ds{:start    (fn [{:keys [->error]}]
-                                                             (->error {:message "Intentional error"}))}}
-                          :app {:http-server #::ds{:start  config-port
-                                                   ;; This ref will always fail to resolve
-                                                   :config {:port (ds/ref [:env :http-port])}}}}}
-             (ds/signal ::ds/start)
-             (select-keys [::ds/out])))
-      "Error messages short-circuit signal handling without failing on ref resolution"))
-
-(deftest signal-validation-short-circuit
-  (is (= #::ds{:out {:validation {:env {:http-port {:message "Intentional validation error"}}}}}
-         (-> #::ds{:defs {:env {:http-port #::ds{:start    (fn [{:keys [->validation]}]
-                                                             (->validation {:message "Intentional validation error"}))}}
-                          :app {:http-server #::ds{:start  config-port
-                                                   ;; This ref will always fail to resolve
-                                                   :config {:port (ds/ref [:env :http-port])}}}}}
-             (ds/signal ::ds/start)
-             (select-keys [::ds/out])))
-      "Validation messages short-circuit signal handling without failing on ref resolution"))
-
 (deftest lifecycle-values-ignored-when-not-system
   (let [expected #::ds{:instances {:env {:http-port 9090}
                                    :app {:http-server 9090}}}
@@ -233,19 +210,6 @@
                                       ::ds/post-start (fn [_] (swap! store conj :post-start))}}}})
       (is (= [:pre-start :start :post-start] @store)))))
 
-(deftest channel-fns-test
-  (testing "can chain channel fns"
-    (is (= #::ds{:instances {:app {:http-server 9090
-                                   :http-port   9090}}
-                 :out       {:info {:app {:http-server "info"}}}}
-           (-> #::ds{:defs {:app {:http-server #::ds{:start  (fn [{:keys [::ds/config ->instance ->info]}]
-                                                               (-> (->instance (:port config))
-                                                                   (->info "info")))
-                                                     :config {:port (ds/local-ref [:http-port])}}
-                                  :http-port   9090}}}
-               (ds/signal ::ds/start)
-               (select-keys [::ds/instances ::ds/out]))))))
-
 (deftest subsystem-test
   (let [subsystem #::ds{:defs
                         {:local {:port 9090}
@@ -253,13 +217,9 @@
                          :app
                          {:local  #::ds{:start (fn [_] :local)}
                           :server #::ds{:start      (fn [{:keys [::ds/config]}] config)
-                                        :post-start (fn [{:keys [->info]}]
-                                                      (->info "started"))
                                         :stop       (fn [{:keys [::ds/instance]}]
                                                       {:prev instance
                                                        :now  :stopped})
-                                        :post-stop  (fn [{:keys [->info]}]
-                                                      (->info "stopped"))
                                         :config     {:job-queue (ds/ref [:common-services :job-queue])
                                                      :db        (ds/ref [:common-services :db])
                                                      :port      (ds/ref [:local :port])
@@ -289,9 +249,6 @@
             :local     :local}
            (get-in started [::ds/instances :sub-systems :system-1 ::ds/instances :app :server])
            (get-in started [::ds/instances :sub-systems :system-2 ::ds/instances :app :server])))
-    (is (= "started"
-           (get-in started [::ds/out :info :sub-systems :system-1 :app :server])
-           (get-in started [::ds/out :info :sub-systems :system-2 :app :server])))
 
     (let [stopped (ds/signal started ::ds/stop)]
       (is (= {:prev {:job-queue "job queue"
@@ -300,11 +257,7 @@
                      :local     :local}
               :now  :stopped}
              (get-in stopped [::ds/instances :sub-systems :system-1 ::ds/instances :app :server])
-             (get-in stopped [::ds/instances :sub-systems :system-2 ::ds/instances :app :server])))
-
-      (is (= "stopped"
-             (get-in stopped [::ds/out :info :sub-systems :system-1 :app :server])
-             (get-in stopped [::ds/out :info :sub-systems :system-2 :app :server]))))))
+             (get-in stopped [::ds/instances :sub-systems :system-2 ::ds/instances :app :server]))))))
 
 (deftest select-components-test
   (testing "if you specify components, the union of their subgraphs is used"


### PR DESCRIPTION
The channel fns were confusing and we couldn't find a good use for them. This removes them.

A `::ds/component-meta` signal handler key is introduced. Its value is an atom, and you can use it to convey state across the entire lifecycle of a signal application. The final value of the atom is stored in the system map under `::component-meta`. This example should illustrate:


```clojure
(deftest component-meta-test
  (let [system {::ds/defs {:group {:component #::ds{:pre-start  (fn [{:keys [::ds/component-meta]}]
                                                                  (reset! component-meta [::ds/pre-start]))
                                                    :start      (fn [{:keys [::ds/component-meta]}]
                                                                  (swap! component-meta conj ::ds/start))
                                                    :post-start (fn [{:keys [::ds/component-meta]}]
                                                                  (swap! component-meta conj ::ds/post-start))}}}}]
    (is (= [::ds/pre-start ::ds/start ::ds/post-start]
           (get-in (ds/start system) [::ds/component-meta :group :component])))))
```