### PR TITLE
Async / parallel signaling alternative

### DIFF
--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -780,14 +780,13 @@
         false))))
 
 (defn merge-system-states
-  [state-1 state-2]
+  [state-1 state-2 component-id]
   (reduce (fn [result-state [path value]]
             (assoc-in result-state path value))
           state-1
-          (for [facet        (keys state-2)
-                component-id (component-ids state-2)
-                :let         [path (into [facet] component-id)]
-                :when        (contains-path? state-2 path)]
+          (for [facet [::instances ::resolved-defs ::component-meta]
+                :let  [path (into [facet] component-id)]
+                :when (contains-path? state-2 path)]
             [path (get-in state-2 path)])))
 
 #?(:clj
@@ -817,7 +816,7 @@
                       children   (lg/successors signal-computation-graph node)
                       state-val  (swap! state #(-> %
                                                    (update :completed-nodes conj node)
-                                                   (update :result-system merge-system-states new-system)))]
+                                                   (update :result-system merge-system-states new-system node)))]
                   (when (= (:completed-nodes state-val)
                            (set (lg/nodes signal-computation-graph)))
                     (deliver completed-promise true))

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -764,7 +764,7 @@
         (recur (apply-signal-stage system computation-stage-node))))))
 
 ;;---
-;; parallel component signaling
+;; async component signaling
 ;;---
 
 (defn merge-system-states

--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -763,6 +763,10 @@
         system
         (recur (apply-signal-stage system computation-stage-node))))))
 
+;;---
+;; parallel component signaling
+;;---
+
 (defn merge-system-states
   [state-1 state-2 [component-group-name component-name]]
   (reduce (fn [result-state [path value]]
@@ -789,6 +793,12 @@
 #?(:clj
    (do
      (defn- compute-nodes-async
+       "The strategy here is for each signal node to get computed, and merge the result
+  into an accumulating final system.
+
+  When a node is finished executing, it's responsible for enqueuing all of its
+  successor nodes that are ready. Successor nodes are ready when all of their
+  predecessors are completed."
        [{:keys [state nodes-to-compute completion-promise]}]
        (let [{:keys [::execute ::signal-computation-graph] :as system} (:result-system @state)]
          (doseq [node nodes-to-compute]

--- a/test/donut/system_test.cljc
+++ b/test/donut/system_test.cljc
@@ -1,11 +1,38 @@
 (ns donut.system-test
   (:require
-   #?(:clj [clojure.test :refer [deftest is testing]]
+   #?(:clj [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer [deftest is testing] :include-macros true])
    [donut.system :as ds :include-macros true]
    [loom.alg :as la]
    [loom.graph :as lg]
-   [clojure.string :as str]))
+   [clojure.string :as str])
+  #?(:clj
+     (:import [java.util.concurrent Executors])))
+
+#?(:clj
+   (do
+     (defn with-thread-pool [f]
+       (let [thread-pool (Executors/newFixedThreadPool 8)
+             original @#'ds/apply-signal-computation-graph
+             add-exec (fn [system]
+                        (-> system
+                            (update ::ds/execute #(or % (fn [f] (.execute thread-pool f))))
+                            original))]
+         (alter-var-root
+          #'ds/apply-signal-computation-graph
+          (constantly add-exec))
+         (try
+           (f)
+           (finally
+             (.shutdownNow thread-pool)
+             (alter-var-root
+              #'ds/apply-signal-computation-graph
+              (constantly original))))))
+
+     (when (System/getenv "TEST_FORCE_THREAD_POOL")
+       (use-fixtures :once with-thread-pool))))
+
+
 
 (defn config-port
   [opts]
@@ -664,3 +691,39 @@
                                                                   (swap! component-meta conj ::ds/post-start))}}}}]
     (is (= [::ds/pre-start ::ds/start ::ds/post-start]
            (get-in (ds/start system) [::ds/component-meta :group :component])))))
+
+(deftest many-refs-test
+  (testing "A large number of components with interdependent refs are processed correctly"
+    (let [kw #(keyword (str "c" %))
+          component (fn [ref]
+                      {::ds/config ref
+                       ::ds/start
+                       (fn [{::ds/keys [config]}]
+                         (inc config))})
+          system {::ds/defs
+                  {:test
+                   (->> (range 1 128)
+                        (map #(do [(kw %) (component (ds/local-ref [(kw (quot % 2))]))]))
+                        (into {:c0 1}))}}]
+      (is (= {1 1, 2 1, 3 2, 4 4, 5 8, 6 16, 7 32, 8 64}
+             (-> system ds/start ::ds/instances :test vals frequencies))))))
+
+#?(:clj
+   (deftest parallel-start-test
+     (let [a (promise)
+           b (promise)
+           ;; Provide enough threads to allow the signal to send all 6 signals at
+           ;; once, to make sure that it won't.
+           executor (Executors/newFixedThreadPool 6)]
+       (is (= {:app {:beep "boop"
+                     :boop "beep"}}
+              ;; Create a system that can't start unless run concurrently
+              (-> #::ds{:defs {:app {:beep {::ds/start (fn [_] (deliver b "beep") @a)}
+                                     :boop {::ds/start (fn [_] (deliver a "boop") @b)}}}
+                        :execute (fn [f] (.execute executor f))}
+                  (ds/signal ::ds/start)
+                  future
+                  (deref 1000 {::ds/instances :timeout})
+                  ::ds/instances))
+           "System can be started by sending signals in parallel")
+       (.shutdown executor))))

--- a/test/donut/system_test.cljc
+++ b/test/donut/system_test.cljc
@@ -32,8 +32,6 @@
      (when (System/getenv "TEST_FORCE_THREAD_POOL")
        (use-fixtures :once with-thread-pool))))
 
-
-
 (defn config-port
   [opts]
   (get-in opts [::ds/config :port]))

--- a/test/donut/system_test.cljc
+++ b/test/donut/system_test.cljc
@@ -334,13 +334,15 @@
     (is (= 1 @start-count)
         "parent system signals only applied once")
 
-    (let [stopped (ds/signal started ::ds/stop)]
-      (is (= {:prev {:job-queue "job queue"
-                     :db        "db"
-                     :port      9090
-                     :local     :local}
-              :now  :stopped}
-             (get-in stopped [::ds/instances :sub-systems :system-1 ::ds/instances :app :server])
+    (let [stopped  (ds/signal started ::ds/stop)
+          expected {:prev {:job-queue "job queue"
+                           :db        "db"
+                           :port      9090
+                           :local     :local}
+                    :now  :stopped}]
+      (is (= expected
+             (get-in stopped [::ds/instances :sub-systems :system-1 ::ds/instances :app :server])))
+      (is (= expected
              (get-in stopped [::ds/instances :sub-systems :system-2 ::ds/instances :app :server]))))))
 
 (deftest select-components-test


### PR DESCRIPTION
@john-shaffer I finally got to looking at your PR, it's really helpful! I appreciate it a lot.

I ended up trying to put together an implementation iterating on your work, mostly so that I could understand what was going on but also because I had a couple thoughts about how things could be organized:

* I tried to organize it so that the `::execute` function would only have to be responsible for making sure the thunk gets executed, and not for have it need to be aware of a promise or of a result map with a `:result` or `:error` key
* as a result of this exceptions get handled in a different way - it felt similarly desirable to have the core async loop be responsible for exception handling and not leave it up to an `::execute` fn
* the strategy for submitting work to be executed is kind of inverted, but not really. I tried to structure it so that every time a computation node gets run, it  also submits its ready children to be run, and make it so that that relationship is clear

would love to hear your thoughts!

Really really appreciate the PR you put up!