### PR TITLE
different strategy for async signal handling

### DIFF
--- a/test/donut/system_test.cljc
+++ b/test/donut/system_test.cljc
@@ -16,7 +16,7 @@
              original @#'ds/apply-signal-computation-graph
              add-exec (fn [system]
                         (-> system
-                            (update ::ds/execute #(or % (ds/execute-fn thread-pool)))
+                            (update ::ds/execute #(or % (fn [f] (.execute thread-pool f))))
                             original))]
          (alter-var-root
           #'ds/apply-signal-computation-graph
@@ -710,17 +710,18 @@
    (deftest parallel-start-test
      (let [a (promise)
            b (promise)
-        ; Provide enough threads to allow the signal to send all 6 signals at
-        ; once, to make sure that it won't.
+           ;; Provide enough threads to allow the signal to send all 6 signals at
+           ;; once, to make sure that it won't.
            executor (Executors/newFixedThreadPool 6)]
        (is (= {:app {:beep "boop"
                      :boop "beep"}}
-           ; Create a system that can't start unless run concurrently
+              ;; Create a system that can't start unless run concurrently
               (-> #::ds{:defs {:app {:beep {::ds/start (fn [_] (deliver b "beep") @a)}
                                      :boop {::ds/start (fn [_] (deliver a "boop") @b)}}}
-                        :execute (ds/execute-fn executor)}
+                        :execute (fn [f] (.execute executor f))}
                   (ds/signal ::ds/start)
-                  future (deref 1000 {::ds/instances :timeout})
+                  future
+                  (deref 1000 {::ds/instances :timeout})
                   ::ds/instances))
            "System can be started by sending signals in parallel")
        (.shutdown executor))))


### PR DESCRIPTION
don't require execute fn to manage promises, handle exceptions, or do anything beyond submitting work. might want to call it submit-work?