### PR TITLE
Fix crash when parsing exception with nil message

### DIFF
--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -726,7 +726,7 @@
   [system computation-stage throwable]
   (let [message #?(:clj (.getMessage throwable)
                    :cljs (. throwable -message))]
-    (if (re-find #"^:donut.system" message)
+    (if (some->> message (re-find #"^:donut.system"))
       ;; let donut.system exceptions flow through
       throwable
       (let [ei (ex-info (str "Error on " computation-stage " when applying signal")


### PR DESCRIPTION
I had a system where a start fn ran `(io/resource nil)`, which throws a NullPointerException with a nil message. `apply-signal-exception` calls re-find on this nil value, which causes another NPE that obscures the original problem.

- Only call re-find for non-nil values.
- Add test case for handling of an exception with a nil message.