### PR TITLE
Improve select-components docs and tests

### DIFF
--- a/src/donut/system.cljc
+++ b/src/donut/system.cljc
@@ -851,8 +851,13 @@
 ;;---
 
 (defn select-components
-  "You can scope down what component keys to use. In subsequent interactions with
-  a system, use only those component keys."
+  "Returns a new system with component selection noted, so that
+   when you send signals to the new system the signals are only
+   sent to the selected components and the components they
+   depend on (recursively).
+
+   If you include a keyword in the selected components set,
+   then all components in that group will be selected."
   [system component-keys]
   (assoc system
          ::selected-component-ids

--- a/test/donut/system_test.cljc
+++ b/test/donut/system_test.cljc
@@ -346,7 +346,10 @@
 (deftest select-components-test
   (testing "if you specify components, the union of their subgraphs is used"
     (let [system-def {::ds/defs {:env {:http-port #::ds{:start 9090}}
-                                 :app {:http-server #::ds{:start  config-port
+                                 :app {; Test that dependents are not included in the subgraph
+                                       :after-http  #::ds{:config {:depends-on (ds/local-ref [:http-server])}
+                                                          :start "after http-server"}
+                                       :http-server #::ds{:start  config-port
                                                           :stop   "stopped http-server"
                                                           :config {:port (ds/ref [:env :http-port])}}
                                        :db          #::ds{:start "db"


### PR DESCRIPTION
- I just copied the text from the README to the docstring since its explanation is much better.
- Explicitly test that while select-components sends signals to dependencies of the selected components, it does not send signals to dependents.